### PR TITLE
`extractBilibiliSourceId`の`console.log`を消す

### DIFF
--- a/utils/extractSourceId.ts
+++ b/utils/extractSourceId.ts
@@ -51,7 +51,6 @@ export const extractBilibiliSourceId = (input: string) => {
   const url = mkUrl(input);
   if (url) {
     if (url.hostname === "www.bilibili.com") {
-      console.log(url.pathname);
       const maybe = /^\/video\/(BV[A-Za-z0-9]{10})\/?$/.exec(url.pathname);
       if (maybe && isValidBilibiliBvid(maybe[1])) return maybe[1];
     }


### PR DESCRIPTION
Fixes #782